### PR TITLE
Replace "or", "and", "not" with "||", "&&", "!"

### DIFF
--- a/include/sot_bits/optimizer.h
+++ b/include/sot_bits/optimizer.h
@@ -242,7 +242,7 @@ namespace sot {
                         int budget = mMaxEvals - mNumEvals - 1;
                         // Restart if sigma is too small and the budget 
                         // is larger than the initial design
-                        if (sigma < mSigmaMin and budget > mInitPoints) {
+                        if (sigma < mSigmaMin && budget > mInitPoints) {
                             fBestLoc = std::numeric_limits<double>::max();
                             mSurf->reset();
                             mSampling->reset(mMaxEvals - mNumEvals - mInitPoints);

--- a/include/sot_bits/rbf.h
+++ b/include/sot_bits/rbf.h
@@ -633,7 +633,7 @@ namespace sot {
          */
         double eval(const vec &ppoint, const vec &dists) const {
             if(mDirty) { throw std::logic_error("RBF not updated. You need to call fit() first"); }       
-            if(not (arma::all(mxLow == 0) and arma::all(mxUp == 1))) { 
+            if(!(arma::all(mxLow == 0) && arma::all(mxUp == 1))) { 
                 std::cout << "RBF uses internal scaling so distances have to be recomputed" << std::endl;
                 return eval(ppoint);
             }     
@@ -677,7 +677,7 @@ namespace sot {
          */
         vec evals(const mat &ppoints, const mat &dists) const {
             if(mDirty) { throw std::logic_error("RBF not updated. You need to call fit() first"); }       
-            if(not (arma::all(mxLow == 0) and arma::all(mxUp == 1))) { 
+            if(!(arma::all(mxLow == 0) && arma::all(mxUp == 1))) { 
                 std::cout << "RBF uses internal scaling so distances have to be recomputed" << std::endl;
                 return evals(ppoints);
             }       

--- a/include/sot_bits/utils.h
+++ b/include/sot_bits/utils.h
@@ -345,7 +345,7 @@ namespace sot {
          * \throws std::logic_error If the watch hasn't already been started
          */
         double stop() {
-            if(not mStarted) { throw std::logic_error("StopWatch: The StopWatch is not running, so can't stop!"); }
+            if(!mStarted) { throw std::logic_error("StopWatch: The StopWatch is not running, so can't stop!"); }
             mEndTime = std::chrono::system_clock::now();
             mStarted = false;
             std::chrono::duration<double> elapsedSeconds = mEndTime - mStartTime;

--- a/test/test_adaptive.cpp
+++ b/test/test_adaptive.cpp
@@ -38,10 +38,10 @@ int test_adaptive() {
         vec newX = adaptiveSampling[i]->makePoints(xBest, X, sigma, 1);
 
         // Check that the new point is in the domain
-        if (not arma::all(newX <= data->uBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(newX <= data->uBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(newX >= data->lBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(newX >= data->lBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
 
@@ -50,10 +50,10 @@ int test_adaptive() {
         mat newXmat = adaptiveSampling[i]->makePoints(xBest, X, sigma, n);
 
         for(int j=0; j < n; j++) {
-            if (not arma::all(newXmat.col(j) <= data->uBounds())) { // LCOV_EXCL_LINE
+            if (!arma::all(newXmat.col(j) <= data->uBounds())) { // LCOV_EXCL_LINE
                 return (EXIT_FAILURE); // LCOV_EXCL_LINE
             }
-            if (not arma::all(newXmat.col(j) >= data->lBounds())) { // LCOV_EXCL_LINE
+            if (!arma::all(newXmat.col(j) >= data->lBounds())) { // LCOV_EXCL_LINE
                 return (EXIT_FAILURE); // LCOV_EXCL_LINE
             }
         }

--- a/test/test_dds.cpp
+++ b/test/test_dds.cpp
@@ -35,10 +35,10 @@ int test_dycors() {
         if (res.fBest() > -18.0) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
     }

--- a/test/test_dycors.cpp
+++ b/test/test_dycors.cpp
@@ -39,10 +39,10 @@ int test_dycors() {
         if (res.fBest() > -20.0) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
     }

--- a/test/test_ga.cpp
+++ b/test/test_ga.cpp
@@ -37,10 +37,10 @@ int test_dycors() {
         if (res.fBest() > -15.0) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
     }

--- a/test/test_ga_sampling.cpp
+++ b/test/test_ga_sampling.cpp
@@ -39,10 +39,10 @@ int test_ga_sampling() {
         if (res.fBest() > -20.0) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
     }

--- a/test/test_kNN.cpp
+++ b/test/test_kNN.cpp
@@ -97,7 +97,7 @@ int test_kNN() {
         exceptionThrown = true;
     }
 
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
     return (EXIT_SUCCESS);
 }

--- a/test/test_optprobs.cpp
+++ b/test/test_optprobs.cpp
@@ -53,7 +53,7 @@ int test_optprobs() {
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
 
-        if(not arma::all(lBounds < uBounds)) { // LCOV_EXCL_LINE
+        if(!arma::all(lBounds < uBounds)) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
 
@@ -92,10 +92,10 @@ int test_optprobs() {
                 return (EXIT_FAILURE); // LCOV_EXCL_LINE
             }
             // Check that the translation is in the domain
-            if (not arma::all(translation < uBounds)) { // LCOV_EXCL_LINE
+            if (!arma::all(translation < uBounds)) { // LCOV_EXCL_LINE
                 return (EXIT_FAILURE); // LCOV_EXCL_LINE
             }
-            if (not arma::all(translation > lBounds)) { // LCOV_EXCL_LINE
+            if (!arma::all(translation > lBounds)) { // LCOV_EXCL_LINE
                 return (EXIT_FAILURE); // LCOV_EXCL_LINE
             }
         }

--- a/test/test_rbf.cpp
+++ b/test/test_rbf.cpp
@@ -30,11 +30,11 @@ int test_kernels_tails() {
     // Cubic + Linear should work
     if(check_exception<CubicKernel, LinearTail>(maxPoints, dim)) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
     // Cubic + Constant should NOT work
-    if(not check_exception<CubicKernel, ConstantTail>(maxPoints, dim)) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!check_exception<CubicKernel, ConstantTail>(maxPoints, dim)) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
     // TPS + Linear should work
     if(check_exception<ThinPlateKernel, LinearTail>(maxPoints, dim)) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
     // TPS + Constant should NOT work
-    if(not check_exception<ThinPlateKernel, ConstantTail>(maxPoints, dim)) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!check_exception<ThinPlateKernel, ConstantTail>(maxPoints, dim)) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
     // Linear + Linear should work
     if(check_exception<LinearKernel, LinearTail>(maxPoints, dim)) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
     // Linear + Constant should work
@@ -186,7 +186,7 @@ int test_rbf() {
     catch (const std::logic_error& e) {
         exceptionThrown = true;
     }
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
     // Check all of the evaluation methods
     vals = arma::zeros(n);

--- a/test/test_shepard.cpp
+++ b/test/test_shepard.cpp
@@ -97,7 +97,7 @@ int test_shepard() {
         exceptionThrown = true;
     }
 
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
 
     return (EXIT_SUCCESS);

--- a/test/test_srbf.cpp
+++ b/test/test_srbf.cpp
@@ -38,10 +38,10 @@ int test_srbf() {
         if (res.fBest() > -20.0) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
-        if (not arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
+        if (!arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
             return (EXIT_FAILURE); // LCOV_EXCL_LINE
         }
     }

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -36,10 +36,10 @@ int test_sync() {
     if (res.fBest() > -20.0) { // LCOV_EXCL_LINE
         return (EXIT_FAILURE); // LCOV_EXCL_LINE
     }
-    if (not arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
+    if (!arma::all(res.xBest() >= data->lBounds())) { // LCOV_EXCL_LINE
         return (EXIT_FAILURE); // LCOV_EXCL_LINE
     }    
-    if (not arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
+    if (!arma::all(res.xBest() <= data->uBounds())) { // LCOV_EXCL_LINE
         return (EXIT_FAILURE); // LCOV_EXCL_LINE
     }
     

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -134,7 +134,7 @@ int test_result() {
     catch (const std::logic_error& e) {
         exceptionThrown = true;
     }
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
     // Reset the object
     res.reset();
@@ -147,7 +147,7 @@ int test_result() {
     catch (const std::logic_error& e) {
         exceptionThrown = true;
     }
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
     exceptionThrown = false;
     try {
@@ -156,7 +156,7 @@ int test_result() {
     catch (const std::logic_error& e) {
         exceptionThrown = true;
     }
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
     exceptionThrown = false;
     try {
@@ -165,7 +165,7 @@ int test_result() {
     catch (const std::logic_error& e) {
         exceptionThrown = true;
     }
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
     exceptionThrown = false;
     try {
@@ -174,7 +174,7 @@ int test_result() {
     catch (const std::logic_error& e) {
         exceptionThrown = true;
     }
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
 
     return EXIT_SUCCESS;
@@ -198,14 +198,14 @@ int test_pareto() {
                 break;
             }
         }
-        if(not dominated) {
+        if(!dominated) {
             bruteInd(bruteCounter) = (arma::uword) i;
             bruteCounter++;
         }
     }
 
     bruteInd = bruteInd.rows(0, bruteCounter-1);
-    if(not arma::all(arma::sort(bruteInd) == arma::sort(frontInd))) { return (EXIT_FAILURE); } // LCOV_EXCL_LINE
+    if(!arma::all(arma::sort(bruteInd) == arma::sort(frontInd))) { return (EXIT_FAILURE); } // LCOV_EXCL_LINE
 
     // Make sure that an exception is thrown when x and y have different length
     bool exceptionThrown = false;
@@ -217,7 +217,7 @@ int test_pareto() {
         exceptionThrown = true;
     }
 
-    if(not exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
+    if(!exceptionThrown) { return EXIT_FAILURE; } // LCOV_EXCL_LINE
 
     return EXIT_SUCCESS;
 }
@@ -232,7 +232,7 @@ int test_cumMin() {
         testCumMin(i) = std::min(x(i), testCumMin(i-1));
     }
 
-    if(not arma::all(xCumMin == testCumMin)) { return (EXIT_FAILURE); } // LCOV_EXCL_LINE
+    if(!arma::all(xCumMin == testCumMin)) { return (EXIT_FAILURE); } // LCOV_EXCL_LINE
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Visual Studio compiler (checked on VS17) requires this change
to correctly compile. Fixes #1 